### PR TITLE
Change readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# Oasis Compile 
+# Oasis Compile
 
-[![CircleCI](https://circleci.com/gh/oasislabs/oasis-compiler.svg?style=svg&circle-token=7a42a176ac6ffdeebd1077bc6fdec7da5c614b87)](https://circleci.com/gh/oasislabs/oasis-compiler)
+[![CircleCI](https://circleci.com/gh/oasislabs/oasis-compile.svg?style=svg&circle-token=7a42a176ac6ffdeebd1077bc6fdec7da5c614b87)](https://circleci.com/gh/oasislabs/oasis-compile)
 
 Oasis-compile is a truffle compiler extension used to compile both Solidity
-and Rust contracts with or without confidentiality.
+and Rust contracts with or without confidentiality. It is expected to run
+within the context of the Oasis Contract-Kit, particularly for the use of
+compiling Rust contracts.
 
 ## USAGE:
 


### PR DESCRIPTION
Needed after repo name change to `oasis-compile`